### PR TITLE
Fix JS console error when there's no latest news.

### DIFF
--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -149,7 +149,7 @@ window.Timelord = {
 		Timelord.callAPI({
 			url: Timelord._config.api_endpoints.breakingNews,
 			success: function (data) {
-				if (data.payload.content) {
+				if (data.payload !== null) {
 					Timelord.setBreakingNews(data.payload.content);
 				} else {
 					Timelord.setBreakingNews(false);
@@ -399,8 +399,6 @@ window.Timelord = {
 
 		if (time >= Timelord._config.silence_timeouts.long) {
 			Timelord.setBreakingNews("RADIO SILENCE DETECTED");
-		} else {
-			Timelord.setBreakingNews(false);
 		}
 
 		if (time >= Timelord._config.silence_timeouts.short) {

--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -149,7 +149,11 @@ window.Timelord = {
 		Timelord.callAPI({
 			url: Timelord._config.api_endpoints.breakingNews,
 			success: function (data) {
-				Timelord.setBreakingNews(data.payload.content);
+				if (data.payload.content) {
+					Timelord.setBreakingNews(data.payload.content);
+				} else {
+					Timelord.setBreakingNews(false);
+				}				
 			},
 			complete: function () {
 				setTimeout(Timelord.updateBreakingNews, Timelord._config.request_timeout);


### PR DESCRIPTION
The API sends 'payload' = false when there is no latest news item, causing payload.content to be unavailable. Added a check to make sure it can set the news, otherwise disable breaking news instead.