### PR TITLE
Allow Timelord to check if it can reload.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -110,7 +110,7 @@
 </div>
 
 <footer class="sticky">
-
+	<div id="availability-error">Waiting for Timelord HTTP access...</div>
 	<div class="container-fluid">
 		<div class="row" id="alerts">
 			<div class="col-xs-2" id="s1">Studio 1</div>

--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -594,13 +594,12 @@ window.Timelord = {
 	checkTimelordAvailability: function () {
 		var timelordAvailable = false;
 		$.ajax({url: window.location.href, success: function(result){
-        window.location = window.location.href;
-    }, error: function(result){
+      	window.location = window.location.href;
+			}, error: function(result){
 				setTimeout(Timelord.checkTimelordAvailability,300000);
 				$('#availability-error').show();
-		}
+			}
 		});
 	}
-
 
 };

--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -22,9 +22,7 @@ window.Timelord = {
 		Timelord._$ = $;
 		Timelord._config = config;
 
-
-		// @TODO See if this can be removed
-		setTimeout("window.location = window.location.href", 18000000);
+		setTimeout(Timelord.checkTimelordAvailability, 18000000);
 
 		Timelord.loop();
 		Timelord.updateView();
@@ -60,8 +58,8 @@ window.Timelord = {
 			} else {
 				Timelord._$('#countdown101').text(msToString(Timelord.endTime101.diff(t)));
 			}
-		
-	
+
+
 		} else {
 			Timelord._$('#countdown101').text("");
 		}
@@ -153,7 +151,7 @@ window.Timelord = {
 					Timelord.setBreakingNews(data.payload.content);
 				} else {
 					Timelord.setBreakingNews(false);
-				}				
+				}
 			},
 			complete: function () {
 				setTimeout(Timelord.updateBreakingNews, Timelord._config.request_timeout);
@@ -590,6 +588,18 @@ window.Timelord = {
 
 		Timelord._$.ajax(options);
 
+	},
+
+	/* Checks if Timelord is available to reload from server, if so, reload. If not, show error. */
+	checkTimelordAvailability: function () {
+		var timelordAvailable = false;
+		$.ajax({url: window.location.href, success: function(result){
+        window.location = window.location.href;
+    }, error: function(result){
+				setTimeout(Timelord.checkTimelordAvailability,300000);
+				$('#availability-error').show();
+		}
+		});
 	}
 
 

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -176,6 +176,16 @@ footer.sticky {
 
 }
 
+#availability-error {
+
+	color: red;
+  font-size: 24px;
+  margin-top: -30px;
+  height: 30px;
+  display: none;
+
+}
+
 #alerts {
 
   & > * {


### PR DESCRIPTION
Adding to the previous auto refresh code, this allows Timelord to check if the webpage is still available to be reloaded. If it is, reload the page (facilitates automatic deployment of future Timelord updates), otherwise display an error until it can access the page again.

This should prevent the need for the page to be refreshed manually if the webpage is lost.