### PR TITLE
Reduce API polling when not required.

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,8 @@
 	"long": 20
   },
   "icecast_json_url": "http://audio.ury.org.uk/status-json.xsl",
-  "request_timeout": 3000,
+  "request_timeout_high_pri": 3000,
+  "request_timeout_low_pri": 6000,
   "short_name": "URY",
   "long_name": "University Radio York",
   "refresh_on_error": false

--- a/config.json
+++ b/config.json
@@ -23,7 +23,7 @@
   },
   "icecast_json_url": "http://audio.ury.org.uk/status-json.xsl",
   "request_timeout_high_pri": 3000,
-  "request_timeout_low_pri": 6000,
+  "request_timeout_low_pri": 10000,
   "short_name": "URY",
   "long_name": "University Radio York",
   "refresh_on_error": false

--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -142,7 +142,7 @@ window.Timelord = {
 				Timelord.setStudioPowerLevel(data.payload);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateStudioInfo, Timelord._config.request_timeout_low_pri);
+				setTimeout(Timelord.updateStudioInfo, Timelord._config.request_timeout_high_pri);
 			}
 		});
 

--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -123,7 +123,7 @@ window.Timelord = {
 				}
 			},
 			complete: function () {
-				setTimeout(Timelord.updateBreakingNews, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateBreakingNews, Timelord._config.request_timeout_low_pri);
 			}
 		});
 
@@ -142,7 +142,7 @@ window.Timelord = {
 				Timelord.setStudioPowerLevel(data.payload);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateStudioInfo, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateStudioInfo, Timelord._config.request_timeout_low_pri);
 			}
 		});
 
@@ -161,7 +161,7 @@ window.Timelord = {
 				Timelord.setShows(data.payload);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateShowInfo, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateShowInfo, Timelord._config.request_timeout_low_pri);
 			}
 		});
 
@@ -199,7 +199,7 @@ window.Timelord = {
 				Timelord.setTrack(track);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateTrack, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateTrack, Timelord._config.request_timeout_high_pri);
 			},
 			error: function() {
 				Timelord.setTrack("");
@@ -236,7 +236,7 @@ window.Timelord = {
 				Timelord.setObitAlert(data.payload);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateObitAlert, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateObitAlert, Timelord._config.request_timeout_low_pri);
 			}
 		});
 
@@ -254,7 +254,7 @@ window.Timelord = {
 				Timelord.setSilenceAlert(data.payload);
 			},
 			complete: function () {
-				setTimeout(Timelord.updateSilenceAlert, Timelord._config.request_timeout);
+				setTimeout(Timelord.updateSilenceAlert, Timelord._config.request_timeout_high_pri);
 			}
 		});
 


### PR DESCRIPTION
We don't need to poll every endpoint of timelord every 3 seconds. Split it up into two speeds.