### PR TITLE
add autonews

### DIFF
--- a/src/scripts/timelord.js
+++ b/src/scripts/timelord.js
@@ -360,6 +360,7 @@ window.Timelord = {
 	setStudio: function (studio) {
 
 		Timelord._$('#studio')
+			.removeClass("studio0") // AutoNews
 			.removeClass('studio1')
 			.removeClass('studio2')
 			.removeClass('studio3')
@@ -367,11 +368,22 @@ window.Timelord = {
 			.removeClass('studio5')
 			.removeClass('studio8');
 
+		var t = moment();
+		if (studio === 5 && ((t.minutes() === 59 && t.seconds() >= 45) ||
+			t.minutes() === 00 ||
+			t.minutes() === 01 ||
+			(t.minutes() === 02 && t.seconds() < 02))) {
+			studio = 0;
+		}
+
 		Timelord._$('#studio').addClass('studio' + studio);
 
 		var studioText;
 		var onAirText = ' is On Air';
 		switch (studio) {
+			case 0:
+				studioText = 'AutoNews' + onAirText;
+				break;
 			case 1:
 				studioText = 'Studio Red' + onAirText;
 				break;

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -168,6 +168,11 @@ footer.sticky {
     font-weight: bold;
     font-size: 6.5em;
 
+    //AutoNews
+    &.studio0 {
+	color: #2CDFFF;
+    }
+
     //Studio 1
     &.studio1 {
       color: red;


### PR DESCRIPTION
_attempt two of this after formatting fun_

if source 5 is on, and during the news, it'll say autonews is on air, by setting it as source 0

this is beneficial for presenters who don't know all the techinical details, such as "webstudio has autonews"

the only time this fails is WS shows having no autonews, but that is much less common than normal studio shows wanting autonews